### PR TITLE
Re-use options used at create skeleton to future

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,21 +24,14 @@ How it works?
       -p, [--target=TARGET]                    # Define the target directory
                                                # Default: .
       -m, [--maintainer=MAINTAINER]            # Maintainer's name
-                                               # Default: The maintainer's name
       -e, [--maintainer-mail=MAINTAINER_MAIL]  # Maintainer's mail
-                                               # Default: maintainer@email.here
       -a, [--abstract=ABSTRACT]                # Defines a short description to abstract
-                                               # Default: A short description
       -l, [--license=LICENSE]                  # The extension license.
-                                               # Default: postgresql
       -v, [--version=VERSION]                  # Initial version
-                                               # Default: 0.0.1
       -d, [--description=DESCRIPTION]          # A long text that contains more information about extension
-                                               # Default: A long description
       -b, [--generated-by=GENERATED_BY]        # Name of extension's generator
       -t, [--tags=one two three]               # Defines extension's tags
       -r, [--release-status=RELEASE_STATUS]    # Initial extension's release status
-                                               # Default: unstable
 
 See in action...
 

--- a/lib/pgxn_utils.rb
+++ b/lib/pgxn_utils.rb
@@ -1,4 +1,5 @@
 require 'thor'
+require 'json'
 
 module PgxnUtils
  autoload :CLI, 'pgxn_utils/cli'

--- a/lib/pgxn_utils/cli.rb
+++ b/lib/pgxn_utils/cli.rb
@@ -1,6 +1,6 @@
 module PgxnUtils
   class CLI < Thor
-    attr_accessor :extension_name, :target, :maintainer, :maintainer_mail
+    attr_accessor :extension_name, :target, :maintainer #, :maintainer_mail
     attr_accessor :abstract, :description, :version, :tags
     attr_accessor :license, :release_status, :generated_by
 
@@ -8,20 +8,20 @@ module PgxnUtils
 
     desc "skeleton extension_name", "Creates an extension skeleton in current directory."
 
-    method_option :target,            :aliases => "-p", :default => ".",    :desc => "Define the target directory"
+    method_option :target,            :aliases => "-p", :default => ".",  :desc => "Define the target directory"
 
     # META required fields
-    method_option :maintainer,        :aliases => "-m", :type => :string,   :default => "The maintainer's name", :desc => "Maintainer's name"
-    method_option :maintainer_mail,   :aliases => "-e", :type => :string,   :default => "maintainer@email.here", :desc => "Maintainer's mail"
-    method_option :abstract,          :aliases => "-a", :type => :string,   :default => "A short description",   :desc => "Defines a short description to abstract"
-    method_option :license,           :aliases => "-l", :type => :string,   :default => "postgresql",            :desc => "The extension license."
-    method_option :version,           :aliases => "-v", :type => :string,   :default => "0.0.1",                 :desc => "Initial version"
+    method_option :maintainer,        :aliases => "-m", :type => :string, :desc => "Maintainer's name <maintainer@email>"
+    #method_option :maintainer_mail,   :aliases => "-e", :type => :string, :desc => "Maintainer's mail"
+    method_option :abstract,          :aliases => "-a", :type => :string, :desc => "Defines a short description to abstract"
+    method_option :license,           :aliases => "-l", :type => :string, :desc => "The extension license."
+    method_option :version,           :aliases => "-v", :type => :string, :desc => "Initial version"
 
     # META optional fields
-    method_option :description,       :aliases => "-d", :type => :string,  :default => "A long description",     :desc => "A long text that contains more information about extension"
-    method_option :generated_by,      :aliases => "-b", :type => :string,                                        :desc => "Name of extension's generator"
-    method_option :tags,              :aliases => "-t", :type => :array,                                         :desc => "Defines extension's tags"
-    method_option :release_status,    :aliases => "-r", :type => :string,  :default => "unstable",               :desc => "Initial extension's release status"
+    method_option :description,       :aliases => "-d", :type => :string, :desc => "A long text that contains more information about extension"
+    method_option :generated_by,      :aliases => "-b", :type => :string, :desc => "Name of extension's generator"
+    method_option :tags,              :aliases => "-t", :type => :array,  :desc => "Defines extension's tags"
+    method_option :release_status,    :aliases => "-r", :type => :string, :desc => "Initial extension's release status"
 
     def skeleton(extension_name)
       self.set_accessors extension_name
@@ -30,20 +30,31 @@ module PgxnUtils
     end
 
     no_tasks do
+
+      def config_options
+        file = "#{self.target}/#{self.extension_name}/META.json"
+        if File.exist?(file)
+          @@config_options ||= JSON.load(File.read(file))
+        else
+          {}
+        end
+
+      end
+
       def set_accessors(extension_name="your_extension_name")
         self.extension_name = extension_name
 
-        self.target = options[:target]
-        self.maintainer = options[:maintainer]
-        self.maintainer_mail = options[:maintainer_mail]
-        self.abstract = options[:abstract]
-        self.license = options[:license]
-        self.version = options[:version]
+        self.target          = options[:target]
+        self.maintainer      = options[:maintainer]      || config_options["maintainer"]      || "The maintainer's name"
+        #self.maintainer_mail = options[:maintainer_mail] || config_options["maintainer_mail"] || "maintainer@email.here"
+        self.abstract        = options[:abstract]        || config_options["abstract"]        || "A short description"
+        self.license         = options[:license]         || config_options["license"]         || "postgresql"
+        self.version         = options[:version]         || config_options["version"]         || "0.0.1"
 
-        self.description = options[:description]
-        self.generated_by = options[:generated_by]
-        self.tags = options[:tags]
-        self.release_status = options[:release_status]
+        self.description     = options[:description]     || config_options["description"]     || "A long description"
+        self.generated_by    = options[:generated_by]    || config_options["generated_by"]    || maintainer
+        self.tags            = options[:tags]            || config_options["tags"]
+        self.release_status  = options[:release_status]  || config_options["release_status"]  || "unstable"
 
         self.destination_root = target
       end

--- a/lib/pgxn_utils/templates/root/META.json.tt
+++ b/lib/pgxn_utils/templates/root/META.json.tt
@@ -3,7 +3,7 @@
    "abstract": "<%= abstract %>",
    "description": "<%= description %>",
    "version": "<%= version %>",
-   "maintainer": "<%= maintainer %> <<%= maintainer_mail %>>",
+   "maintainer": "<%= maintainer %>",
    "license": "<%= license %>",
    "provides": {
       "<%= extension_name %>": {

--- a/lib/pgxn_utils/templates/root/sql/%extension_name%.sql.tt
+++ b/lib/pgxn_utils/templates/root/sql/%extension_name%.sql.tt
@@ -1,5 +1,5 @@
 /*
- * Author: <%= maintainer %> <<%= maintainer_mail %>>
+ * Author: <%= maintainer %>
  * Created at: <%= Time.now %>
  *
  */ 

--- a/pgxn_utils.gemspec
+++ b/pgxn_utils.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |s|
   s.authors     = ["Dickson S. Guedes"]
   s.email       = ["guedes@guedesoft.net"]
   s.homepage    = "http://github.com/guedes/pgxn-utils"
-  s.summary     = %q{A PGXN set of tools to developers}
+  s.summary     = %q{A PGXN set of tools to PostgreSQL extension's developers}
   s.description = %q{A PGXN set of tools to help developers create and publish your PostgreSQL extensions without pain}
 
   s.rubyforge_project = "pgxn_utils"

--- a/spec/cli_spec.rb
+++ b/spec/cli_spec.rb
@@ -42,10 +42,12 @@ describe PgxnUtils::CLI do
       meta.should match(/"version": "#{expected_version}"/)
       meta.should match(/"license": "postgresql"/)
       meta.should match(/"release_status": "unstable"/)
-      meta.should match(/"#{expected_name} <#{expected_mail}>"/)
+      #TODO: I want define how split this from META
+      #meta.should match(/"#{expected_name} <#{expected_mail}>"/)
+      meta.should match(/"#{expected_name}"/)
       meta.should match(/"file": "sql\/#{expected_extension}.sql"/)
       meta.should match(/"docfile": "doc\/#{expected_extension}.md"/)
-      meta.should_not match(/"generated_by":/)
+      meta.should_not match(/"generated_by": #{expected_name}/)
       meta.should match(/"tags": \[ "one","two","tree" \],/)
 
       makefile = File.read("/tmp/#{expected_extension}/Makefile")


### PR DESCRIPTION
Now, when you create a new extension and sometime
after try to recreate it with 'skeleton', the
arguments has priority, and that args that isn't
explicit passed again, are re-used from META.json.

Refs #1.
