### PR TITLE
Fix upload URI.

### DIFF
--- a/lib/pgxn_utils/constants.rb
+++ b/lib/pgxn_utils/constants.rb
@@ -1,5 +1,5 @@
 module PgxnUtils
   module Constants
-    UPLOAD_URL = URI.parse('https://manager.pgxn.org/auth/upload')
+    UPLOAD_URL = URI.parse('https://manager.pgxn.org/upload')
   end
 end


### PR DESCRIPTION
The server uses a reverse proxy server to map https requests to `/auth`, so the `/auth` bit isn't needed on the URI.

Even with this fix, though, it still fails to work for me, sadly:

```
> pgxn_utils release citext-2.0.1.zip                                          
Enter your PGXN username: theory
Enter your PGXN password: ********************
Uploading to https://manager.pgxn.org/upload
Trying to release citext-2.0.1.zip ... /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:2022:in `read_status_line': wrong status line: "<!DOCTYPE HTML PUBLIC \"-//IETF//DTD HTML 2.0//EN\">" (Net::HTTPBadResponse)
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:2009:in `read_new'
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:1050:in `request'
    from /Library/Ruby/Gems/1.8/gems/pgxn_utils-0.1.2/lib/pgxn_utils/cli.rb:151:in `try_send_file'
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:543:in `start'
    from /System/Library/Frameworks/Ruby.framework/Versions/1.8/usr/lib/ruby/1.8/net/http.rb:440:in `start'
    from /Library/Ruby/Gems/1.8/gems/pgxn_utils-0.1.2/lib/pgxn_utils/cli.rb:149:in `try_send_file'
    from /Library/Ruby/Gems/1.8/gems/pgxn_utils-0.1.2/lib/pgxn_utils/cli.rb:164:in `send_file_to_pgxn'
    from /Library/Ruby/Gems/1.8/gems/pgxn_utils-0.1.2/lib/pgxn_utils/cli.rb:105:in `release'
    from /Library/Ruby/Gems/1.8/gems/thor-0.14.6/lib/thor/task.rb:22:in `send'
    from /Library/Ruby/Gems/1.8/gems/thor-0.14.6/lib/thor/task.rb:22:in `run'
    from /Library/Ruby/Gems/1.8/gems/thor-0.14.6/lib/thor/invocation.rb:118:in `invoke_task'
    from /Library/Ruby/Gems/1.8/gems/thor-0.14.6/lib/thor.rb:263:in `dispatch'
    from /Library/Ruby/Gems/1.8/gems/thor-0.14.6/lib/thor/base.rb:389:in `start'
    from /Library/Ruby/Gems/1.8/gems/pgxn_utils-0.1.2/bin/pgxn_utils:9
    from /usr/bin/pgxn_utils:19:in `load'
    from /usr/bin/pgxn_utils:19
```

No idea what's up with that. :-(
