### PR TITLE
without this fix "sudo make install" not working

### DIFF
--- a/lib/pgxn_utils/templates/c/Makefile.tt
+++ b/lib/pgxn_utils/templates/c/Makefile.tt
@@ -16,7 +16,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 

--- a/lib/pgxn_utils/templates/fdw/Makefile.tt
+++ b/lib/pgxn_utils/templates/fdw/Makefile.tt
@@ -16,7 +16,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 

--- a/lib/pgxn_utils/templates/root/Makefile.tt
+++ b/lib/pgxn_utils/templates/root/Makefile.tt
@@ -16,7 +16,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql) 
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 

--- a/lib/pgxn_utils/templates/sql/Makefile.tt
+++ b/lib/pgxn_utils/templates/sql/Makefile.tt
@@ -20,7 +20,7 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
+DATA = $(wildcard sql/*--*.sql)
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 


### PR DESCRIPTION
in Makefile not allowed duplication of installed files.
without this fix "sudo make install" will show something like this:
/usr/bin/install: just created file «/usr/share/postgresql/9.5/extension/my_cool_c_extension--0.0.1.sql» will be not copied to «.//sql/my_cool_c_extension--0.0.1.sql»
make: *** [install] Error 1
