### PR TITLE
(joe) update json to 2.0.2 to build on ubuntu 16.04

### DIFF
--- a/pgxn_utils.gemspec
+++ b/pgxn_utils.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |s|
     s.specification_version = 3
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
-      s.add_runtime_dependency "json", "~> 1.6.6"
+      s.add_runtime_dependency "json", "~> 2.0.2"
       s.add_runtime_dependency "thor", "~> 0.14"
       s.add_runtime_dependency "rubyzip", "~> 0.9.7"
       s.add_runtime_dependency "multipart-post", "~> 1.1.5"
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
       s.add_development_dependency "mocha"
       s.add_development_dependency "simplecov", "~> 0.4.0"
     else
-      s.add_dependency "json", "~> 1.6.6"
+      s.add_dependency "json", "~> 2.0.2"
       s.add_dependency "thor", "~> 0.14"
       s.add_dependency "rubyzip", "~> 0.9.7"
       s.add_dependency "multipart-post", "~> 1.1.5"
@@ -59,7 +59,7 @@ Gem::Specification.new do |s|
       s.add_dependency "grit", "~> 2.4.1"
     end
   else
-    s.add_dependency "json", "~> 1.6.6"
+    s.add_dependency "json", "~> 2.0.2"
     s.add_dependency "thor", "~> 0.14"
     s.add_dependency "rubyzip", "~> 0.9.7"
     s.add_dependency "multipart-post", "~> 1.1.5"


### PR DESCRIPTION
We're getting an issue with installing, this seems to fix, though there might be a better way:

```
gem install --no-rdoc --no-ri ./pkg/pgxn_utils-0.1.4.gem
Building native extensions.  This could take a while...
ERROR:  Error installing ./pkg/pgxn_utils-0.1.4.gem:
	ERROR: Failed to build gem native extension.

    current directory: /var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator
/usr/bin/ruby2.3 -r ./siteconf20160802-29417-vqvyr9.rb extconf.rb
creating Makefile

current directory: /var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator
make "DESTDIR=" clean
make[1]: Entering directory '/var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator'
make[1]: Leaving directory '/var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator'

current directory: /var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator
make "DESTDIR="
make[1]: Entering directory '/var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator'
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:151:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:151:20: warning: initialization makes integer from pointer without a cast [-Wint-conversion]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
In file included from generator.c:2:0:
generator.c: In function ‘cState_aref’:
generator.h:96:27: warning: variable ‘state’ set but not used [-Wunused-but-set-variable]
     JSON_Generator_State *state;              \
                           ^
generator.c:632:5: note: in expansion of macro ‘GET_STATE’
     GET_STATE(self);
     ^
generator.c: In function ‘isArrayOrObject’:
generator.c:867:22: warning: suggest parentheses around ‘&&’ within ‘||’ [-Wparentheses]
     return *p == '[' && *q == ']' || *p == '{' && *q == '}';
                      ^
Makefile:239: recipe for target 'generator.o' failed
make[1]: *** [generator.o] Error 1
make[1]: Leaving directory '/var/lib/gems/2.3.0/gems/json-1.6.8/ext/json/ext/generator'

make failed, exit code 2

Gem files will remain installed in /var/lib/gems/2.3.0/gems/json-1.6.8 for inspection.
Results logged to /var/lib/gems/2.3.0/extensions/x86_64-linux/2.3.0/json-1.6.8/gem_make.out
Makefile:3: recipe for target 'install' failed
make: *** [install] Error 1
ERROR: command returned 2: make PG_CONFIG=/usr/bin/pg_config install
```