### PR TITLE
Replace deprecated '--no-rdoc --no-ri' flags with '--no-document'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 all:
 	gem build pgxn_utils.gemspec
 install:
-	gem install --no-rdoc --no-ri -v=0.1.6 pgxn_utils
+	gem install --no-document -v=0.1.6 pgxn_utils
 uninstall:
 	gem uninstall -v=0.1.6 pgxn_utils


### PR DESCRIPTION
`--no-rdoc --no-ri` flags are [replaced in ruby 2.6](https://www.ruby-lang.org/en/news/2018/12/25/ruby-2-6-0-released/) with `--no-document`

https://github.com/rubygems/rubygems/pull/2354